### PR TITLE
New patches for port to powerpc64

### DIFF
--- a/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globalDefinitions_ppc.hpp
@@ -50,6 +50,8 @@ const bool CCallingConventionRequiresIntsAsLongs = true;
 #if defined(COMPILER2) && (defined(AIX) || defined(LINUX))
 // Include Transactional Memory lock eliding optimization
 #define INCLUDE_RTM_OPT 1
+#else
+#define INCLUDE_RTM_OPT 0
 #endif
 
 #define SUPPORT_RESERVED_STACK_AREA

--- a/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
@@ -26,6 +26,7 @@
 #include "com_sun_management_internal_OperatingSystemImpl.h"
 
 #include <sys/resource.h>
+#include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/user.h>


### PR DESCRIPTION
These patches update bsd_ppc support to mirror changes to jkd11